### PR TITLE
Add Google Custom Search route

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -48,6 +48,26 @@ app.post('/api/tts', async (req, res) => {
   }
 });
 
+// 4) Google Custom Search
+app.get('/api/search', async (req, res) => {
+  const q = req.query.q;
+  if (!q) {
+    return res.status(400).json({ error: 'Missing q query parameter' });
+  }
+  try {
+    const { data } = await axios.get('https://www.googleapis.com/customsearch/v1', {
+      params: {
+        key: functions.config().google.api_key,
+        cx: functions.config().google.search_cx,
+        q
+      }
+    });
+    res.json(data);
+  } catch (e) {
+    res.status(500).send(e.toString());
+  }
+});
+
 // Export as a single HTTPS function
 exports.api = functions.https.onRequest(app);
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "axios": "^1.9.0",
+    "@googleapis/customsearch": "^7.0.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^5.1.0",


### PR DESCRIPTION
## Summary
- add `@googleapis/customsearch` dependency
- implement `/api/search` route that calls Google Custom Search API

## Testing
- `npm test` *(fails: Error: no test specified)*